### PR TITLE
Support a `default` option on objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,19 +208,55 @@ output = {
 }
 ```
 
-Add title and description:
+Add `title` and `description` annotations to the schema:
 ```js
 ms.obj({
   displayName: 'string',
 }, {title: 'Title', description: 'Desc.'})
+
+output = {
+  type: 'object',
+  title: 'Title',
+  description: 'Desc.',
+  properties: {
+    displayName: {type: 'string'}
+  }
+}
 ```
 
-Add dependencies:
+Add `dependencies`:
 ```js
 ms.obj({
   creditCard: 'string',
   address: 'string'
 }, {dependencies: {creditCard: 'address'}})
+
+output = {
+  type: 'object',
+  properties: {
+    creditCard: {type: 'string'},
+    address: {type: 'string'}
+  },
+  dependencies: {
+    creditCard: ['address']
+  }
+}
+```
+
+Set a `default` value in case the property is absent:
+```js
+ms.obj({
+  creditCard: 'string',
+  address: 'string'
+}, {default: {}})
+
+output = {
+  type: 'object',
+  default: {},
+  properties: {
+    count: {type: 'integer'}
+  }
+}
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -33,20 +33,21 @@ module.exports = {
   // Methods
   // -------
 
-  obj (microschema = {}, {strict, required, title, description, dependencies} = {}) {
+  obj (microschema = {}, opts = {}) {
     const jsonSchema = {
       type: 'object',
       properties: {}
     }
 
-    if (title) jsonSchema.title = title
-    if (description) jsonSchema.description = description
-    if (strict) jsonSchema.additionalProperties = false
-    if (dependencies) setDependencies(jsonSchema, dependencies)
+    if (opts.title) jsonSchema.title = opts.title
+    if (opts.description) jsonSchema.description = opts.description
+    if (opts.strict) jsonSchema.additionalProperties = false
+    if (opts.dependencies) setDependencies(jsonSchema, opts.dependencies)
+    if (opts.default !== undefined) jsonSchema.default = opts.default
 
-    if (required) {
-      if (!Array.isArray(required)) throw new Error("'required' must be an array")
-      jsonSchema.required = required
+    if (opts.required) {
+      if (!Array.isArray(opts.required)) throw new Error("'required' must be an array")
+      jsonSchema.required = opts.required
     }
 
     for (const propertyName in microschema) {

--- a/test.js
+++ b/test.js
@@ -40,6 +40,20 @@ test('obj() creates an object with dependencies', function (t) {
   })
 })
 
+test('obj() supports a default value', function (t) {
+  const schema = ms.obj({
+    foo: 'string'
+  }, {default: {foo: 'bar'}})
+
+  assert.deepEqual(schema, {
+    type: 'object',
+    default: {foo: 'bar'},
+    properties: {
+      foo: {type: 'string'}
+    }
+  })
+})
+
 test('strictObj() creates an object with a single property', function (t) {
   const schema = ms.strictObj({foo: 'string'})
 


### PR DESCRIPTION
### Changelog
- Support a `default` option on `ms.obj`
  ```js
  ms.obj({foo: 'string'}, {default: {foo: 'bar'}})
  ```
  which generates
  ```js
  {type: 'object', default: {foo: 'bar'}, properties: {foo: {type: 'string'}}}
  ```