### PR TITLE
fix: type should not be added when using const

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,6 @@ module.exports = {
 
   const (value) {
     return decorate(this, {
-      type: getJsonType(value),
       const: value
     })
   },

--- a/test.js
+++ b/test.js
@@ -115,8 +115,20 @@ test('enum() creates an enum from an array', function (t) {
 test('const() creates a const value', function (t) {
   const schema = ms.const('foo')
   assert.deepEqual(schema, {
-    type: 'string',
     const: 'foo'
+  })
+})
+
+test('const() creates a required const value', function (t) {
+  const schema = ms.obj({
+    foo: ms.required.const('bar')
+  })
+  assert.deepEqual(schema, {
+    type: 'object',
+    required: ['foo'],
+    properties: {
+      foo: {const: 'bar'}
+    }
   })
 })
 


### PR DESCRIPTION
Previous:
```js
ms.const('foo')
// -> {type: 'string', const: 'foo'}
```

New Behavior:
```js
ms.const('foo')
// -> {const: 'foo'}
```

Json Schema org:
https://json-schema.org/understanding-json-schema/reference/generic.html#constant-values